### PR TITLE
Post to Gambit /chatbot to support Campaign conversations

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -108,6 +108,18 @@ userSchema.methods.promptSignupForCampaign = function (campaign) {
 };
 
 /**
+ * Decline signup for current campaign.
+ * @param {Campaign} campaign
+ * @param {string} source
+ * @param {string} keyword
+ */
+userSchema.methods.declineSignup = function () {
+  // TODO: Decline Signup event.
+  this.signupStatus = 'declined';
+  this.save();
+};
+
+/**
  * Creates an Action model with given type and data.
  */
 userSchema.methods.createAction = function (type, data) {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -14,6 +14,7 @@ const userSchema = new mongoose.Schema({
   paused: Boolean,
   topic: String,
   campaignId: Number,
+  signupStatus: String,
   lastReplyType: String,
 });
 
@@ -68,9 +69,10 @@ userSchema.methods.updateUserTopic = function (newTopic) {
  * @param {Campaign} campaign
  * @return {Promise}
  */
-userSchema.methods.setCampaign = function (campaign) {
+userSchema.methods.setCampaign = function (campaign, signupStatus) {
   this.topic = campaign.topic;
   this.campaignId = campaign._id;
+  this.signupStatus = signupStatus;
 
   return this.save();
 };
@@ -83,7 +85,7 @@ userSchema.methods.setCampaign = function (campaign) {
  */
 userSchema.methods.signupForCampaign = function (campaign, source, keyword) {
   // TODO: Post Signup to DS API.
-  this.setCampaign(campaign);
+  this.setCampaign(campaign, 'doing');
 
   return Signups.create({
     userId: this._id,
@@ -92,6 +94,17 @@ userSchema.methods.signupForCampaign = function (campaign, source, keyword) {
     source,
     keyword,
   });
+};
+
+/**
+ * Prompt signup for current campaign.
+ * @param {Campaign} campaign
+ * @param {string} source
+ * @param {string} keyword
+ */
+userSchema.methods.promptSignupForCampaign = function (campaign) {
+  // TODO: Post Signup to DS API.
+  this.setCampaign(campaign, 'prompt');
 };
 
 /**

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -11,6 +11,7 @@ const Signups = require('./Signup');
 const userSchema = new mongoose.Schema({
   _id: String,
   platform: String,
+  platformId: String,
   paused: Boolean,
   topic: String,
   campaignId: Number,
@@ -24,7 +25,8 @@ const userSchema = new mongoose.Schema({
  */
 userSchema.statics.createFromReq = function (req) {
   const data = {
-    _id: req.userId,
+    _id: new Date().getTime(),
+    platformId: req.userId,
     platform: req.body.platform,
     paused: false,
     // TODO: Move value to config.
@@ -32,6 +34,18 @@ userSchema.statics.createFromReq = function (req) {
   };
 
   return this.create(data);
+};
+
+/**
+ * @param {string} platform
+ * @param {string} platformId
+ * @return {Promise}
+ */
+userSchema.statics.findByPlatformId = function (platform, platformId) {
+  const query = { platform, platformId };
+  logger.debug('User.findByPlatformId', query);
+
+  return this.findOne();
 };
 
 /**
@@ -114,7 +128,7 @@ userSchema.methods.promptSignupForCampaign = function (campaign) {
  * @param {string} keyword
  */
 userSchema.methods.declineSignup = function () {
-  // TODO: Decline Signup event.
+  // TODO: Decline Signup Action.
   this.signupStatus = 'declined';
   this.save();
 };

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -19,8 +19,9 @@ const getBotReplyBrainMiddleware = require('../../lib/middleware/bot-reply-brain
 const brainReplyMiddleware = require('../../lib/middleware/reply-brain');
 const noReplyMiddleware = require('../../lib/middleware/reply-noreply');
 const michaelTopicMiddleware = require('../../lib/middleware/reply-michael');
-const campaignKeywordMiddleware = require('../../lib/middleware/reply-campaign-keyword');
 const campaignMenuMiddleware = require('../../lib/middleware/reply-campaign-menu');
+const getCampaignFromKeywordMiddleware = require('../../lib/middleware/campaign-keyword');
+const getCampaignFromUserMiddleware = require('../../lib/middleware/campaign-current');
 const campaignContinueMiddleware = require('../../lib/middleware/reply-campaign');
 const getBotReplyTextMiddleware = require('../../lib/middleware/bot-reply-text');
 
@@ -35,8 +36,9 @@ router.use(getBotReplyBrainMiddleware());
 router.use(brainReplyMiddleware());
 router.use(noReplyMiddleware());
 router.use(michaelTopicMiddleware());
-router.use(campaignKeywordMiddleware());
 router.use(campaignMenuMiddleware());
+router.use(getCampaignFromKeywordMiddleware());
+router.use(getCampaignFromUserMiddleware());
 router.use(campaignContinueMiddleware());
 // Render response.
 router.use(getBotReplyTextMiddleware());

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -4,6 +4,8 @@ const RiveScript = require('rivescript');
 const Campaigns = require('../app/models/Campaign');
 const config = require('../config/lib/bot');
 
+const defaultTopic = 'random';
+
 let rivescript;
 
 function loadingDone(batchNumber) {
@@ -93,6 +95,9 @@ module.exports.getReply = function (user, userMessage) {
 module.exports.getTopicForUserId = function (userId) {
   const bot = exports.getBot();
   const uservars = bot.getUservars(userId);
+  if (! uservars) {
+    return defaultTopic;
+  }
 
   return uservars.topic;
 };

--- a/lib/gambit.js
+++ b/lib/gambit.js
@@ -2,11 +2,33 @@
 
 const superagent = require('superagent');
 
-const URI = process.env.DS_GAMBIT_CAMPAIGNS_API_BASEURI;
+const uri = process.env.DS_GAMBIT_API_BASEURI;
+const apiKey = process.env.DS_GAMBIT_API_KEY;
 
 module.exports.get = function (endpoint) {
   return superagent
-    .get(`${URI}/${endpoint}`)
+    .get(`${uri}/${endpoint}`)
     .then(response => response.body.data)
     .catch(err => console.log(`gambit response:${err.message}`));
+};
+
+module.exports.post = function (endpoint, data) {
+  return superagent
+    .post(`${uri}/${endpoint}`)
+    .set('x-gambit-api-key', apiKey)
+    .send(data)
+    .then(response => response.body)
+    .catch(err => console.log(`gambit response:${err.message}`));
+};
+
+module.exports.getGambitReply = function (userId, messageText, keyword) {
+  const data = {
+    phone: '201706271241',
+    args: messageText,
+    keyword,
+  };
+
+  return this.post('chatbot', data)
+    .then(res => res.success.message)
+    .catch(err => console.log(err));
 };

--- a/lib/gambit.js
+++ b/lib/gambit.js
@@ -19,7 +19,7 @@ module.exports.post = function (endpoint, data) {
     .set('x-gambit-api-key', apiKey)
     .send(data)
     .then(response => response.body)
-    .catch(err => console.log(`gambit response:${err.message}`));
+    .catch(err => logger.error(err));
 };
 
 module.exports.getGambitReply = function (userId, messageText, keyword) {
@@ -32,5 +32,5 @@ module.exports.getGambitReply = function (userId, messageText, keyword) {
 
   return this.post('chatbot', data)
     .then(res => res.success.message)
-    .catch(err => console.log(err));
+    .catch(err => err.message);
 };

--- a/lib/gambit.js
+++ b/lib/gambit.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const superagent = require('superagent');
+const logger = require('heroku-logger');
 
 const uri = process.env.DS_GAMBIT_API_BASEURI;
 const apiKey = process.env.DS_GAMBIT_API_KEY;
@@ -27,6 +28,7 @@ module.exports.getGambitReply = function (userId, messageText, keyword) {
     args: messageText,
     keyword,
   };
+  logger.debug('gambit.getGambitReply', data);
 
   return this.post('chatbot', data)
     .then(res => res.success.message)

--- a/lib/gambit.js
+++ b/lib/gambit.js
@@ -24,7 +24,7 @@ module.exports.post = function (endpoint, data) {
 
 module.exports.getGambitReply = function (userId, messageText, keyword) {
   const data = {
-    phone: '201706271241',
+    phone: userId,
     args: messageText,
     keyword,
   };

--- a/lib/middleware/bot-reply-text.js
+++ b/lib/middleware/bot-reply-text.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Campaigns = require('../../app/models/Campaign');
-
 module.exports = function renderReplyText() {
   return (req, res, next) => {
     if (req.reply.text) {
@@ -18,12 +16,7 @@ module.exports = function renderReplyText() {
       return next();
     }
 
-    return Campaigns.findById(req.user.campaignId)
-      .then((campaign) => {
-        req.reply.text = campaign.getMessageForMessageType(req.reply.type);
-
-        return next();    
-      })
-      .catch(err => console.log(error));
+    req.reply.text = 'Eek, something went wrong. Try saying MENU.';
+    return next();
   };
 };

--- a/lib/middleware/bot-reply-text.js
+++ b/lib/middleware/bot-reply-text.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Campaigns = require('../../app/models/Campaign');
+
 module.exports = function renderReplyText() {
   return (req, res, next) => {
     if (req.reply.text) {
@@ -10,9 +12,18 @@ module.exports = function renderReplyText() {
       return next();
     }
 
-    const campaign = req.campaign;
-    req.reply.text = campaign.getMessageForMessageType(req.reply.type);
+    if (req.campaign) {
+      req.reply.text = req.campaign.getMessageForMessageType(req.reply.type);
 
-    return next();
+      return next();
+    }
+
+    return Campaigns.findById(req.user.campaignId)
+      .then((campaign) => {
+        req.reply.text = campaign.getMessageForMessageType(req.reply.type);
+
+        return next();    
+      })
+      .catch(err => console.log(error));
   };
 };

--- a/lib/middleware/campaign-current.js
+++ b/lib/middleware/campaign-current.js
@@ -15,7 +15,6 @@ module.exports = function getCurrentCampaign() {
         }
 
         req.campaign = campaign;
-        console.log(campaign);
 
         return next();
       });

--- a/lib/middleware/campaign-current.js
+++ b/lib/middleware/campaign-current.js
@@ -2,20 +2,20 @@
 
 const Campaigns = require('../../app/models/Campaign');
 
-module.exports = function replySignupKeyword() {
+module.exports = function getCurrentCampaign() {
   return (req, res, next) => {
-    if (req.reply.type) {
+    if (req.campaign) {
       return next();
     }
 
-    return Campaigns.findByKeyword(req.userCommand)
+    return Campaigns.findById(req.user.campaignId)
       .then((campaign) => {
         if (! campaign) {
           return next();
         }
 
         req.campaign = campaign;
-        req.keyword = req.userCommand;
+        console.log(campaign);
 
         return next();
       });

--- a/lib/middleware/campaign-keyword.js
+++ b/lib/middleware/campaign-keyword.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Campaigns = require('../../app/models/Campaign');
+
+module.exports = function getCampaignForKeyword() {
+  return (req, res, next) => {
+    if (req.reply.type) {
+      return next();
+    }
+
+    return Campaigns.findByKeyword(req.userCommand)
+      .then((campaign) => {
+        if (! campaign) {
+          return next();
+        }
+
+        req.campaign = campaign;
+        req.keyword = req.userCommand;
+
+        return next();
+      });
+  };
+};

--- a/lib/middleware/reply-campaign-keyword.js
+++ b/lib/middleware/reply-campaign-keyword.js
@@ -15,9 +15,7 @@ module.exports = function replySignupKeyword() {
         }
 
         req.campaign = campaign;
-        req.user.signupForCampaign(campaign, 'keyword', req.userCommand);
-        // TODO: Send relevant continue message if User has already started this Campaign.
-        req.reply.type = 'gambitSignupMenuMessage';
+        req.keyword = req.userCommand;
 
         return next();
       });

--- a/lib/middleware/reply-campaign-menu.js
+++ b/lib/middleware/reply-campaign-menu.js
@@ -9,7 +9,15 @@ module.exports = function replyCampaignMenu() {
       return next();
     }
 
-    if (! helpers.isMenuCommand(req.userCommand)) {
+    let prompt = false;
+
+    if (helpers.isMenuCommand(req.userCommand)) {
+      prompt = true;
+    } else if (req.user.signupStatus === 'declined') {
+      prompt = true;
+    }
+
+    if (! prompt) {
       return next();
     }
 

--- a/lib/middleware/reply-campaign-menu.js
+++ b/lib/middleware/reply-campaign-menu.js
@@ -9,23 +9,7 @@ module.exports = function replyCampaignMenu() {
       return next();
     }
 
-    let promptSignup = true;
-
-    // If current user is already in a campaign:
-    if (req.user.topic.includes('campaign')) {
-      // And it's because they declined it, we want to prompt.
-      if (req.user.lastReplyType === 'signupDeclinedMessage') {
-        promptSignup = true;
-      // Or if they sent the menu command, we also want to prompt.
-      } else if (helpers.isMenuCommand(req.userCommand)) {
-        promptSignup = true;
-      // Otherwise we don't want to prompt.
-      } else {
-        promptSignup = false;
-      }
-    }
-
-    if (! promptSignup) {
+   if (!helpers.isMenuCommand(req.userCommand)) {
       return next();
     }
 

--- a/lib/middleware/reply-campaign-menu.js
+++ b/lib/middleware/reply-campaign-menu.js
@@ -9,7 +9,7 @@ module.exports = function replyCampaignMenu() {
       return next();
     }
 
-   if (!helpers.isMenuCommand(req.userCommand)) {
+    if (! helpers.isMenuCommand(req.userCommand)) {
       return next();
     }
 

--- a/lib/middleware/reply-campaign.js
+++ b/lib/middleware/reply-campaign.js
@@ -1,36 +1,20 @@
 'use strict';
 
-const Campaigns = require('../../app/models/Campaign');
+const gambit = require('../gambit');
 
-module.exports = function replyCampaignTopic() {
+module.exports = function getCampaignReply() {
   return (req, res, next) => {
     if (req.reply.type) {
       return next();
     }
 
-    return Campaigns.findById(req.user.campaignId)
-      .then((campaign) => {
-        // Handle edge-case where Campaign model isn't found.
-        req.campaign = campaign;
-
-        if (req.reply.brain === 'post_signup') {
-          req.user.signupForCampaign(campaign, 'menu');
-          req.reply.type = 'gambitSignupMenuMessage';
-
-          return next();
-        }
-
-        req.user.setCampaign(campaign);
-
-        if (req.reply.brain === 'decline_signup') {
-          req.reply.type = 'signupDeclinedMessage';
-
-          return next();
-        }
-
-        req.reply.type = 'signupConfirmedMessage';
+    return gambit.getGambitReply(req.userId, req.body.text, req.keyword)
+      .then((gambitReplyText) => {
+        req.reply.type = 'gambit';
+        req.reply.text = gambitReplyText;
 
         return next();
-      });
+      })
+      .catch(err => console.log(err));
   };
 };

--- a/lib/middleware/reply-campaign.js
+++ b/lib/middleware/reply-campaign.js
@@ -10,12 +10,15 @@ module.exports = function getCampaignReply() {
 
     if (req.user.lastReplyType === 'signupPromptMessage') {
       if (req.reply.brain === 'decline_signup') {
+        req.user.declineSignup();
         req.reply.type = 'signupDeclinedMessage';
 
         return next();
-      } else if (req.reply.brain === 'post_signup') {
-        req.user.signupForCampaign(req.campaign);
-        req.keyword = req.campaign.keyword;
+      }
+
+      if (req.reply.brain === 'post_signup') {
+        req.user.signupForCampaign(req.campaign, 'menu');
+        req.keyword = req.campaign.keywords[0];
       }
       // else "Sorry I didn't get that", repeat our prompt message.
     }

--- a/lib/middleware/reply-campaign.js
+++ b/lib/middleware/reply-campaign.js
@@ -8,6 +8,12 @@ module.exports = function getCampaignReply() {
       return next();
     }
 
+    if (process.env.DS_GAMBIT_DISABLED) {
+      req.reply.text = req.reply.brain;
+
+      return next();
+    }
+
     if (req.user.lastReplyType === 'signupPromptMessage') {
       if (req.reply.brain === 'decline_signup') {
         req.user.declineSignup();

--- a/lib/middleware/reply-campaign.js
+++ b/lib/middleware/reply-campaign.js
@@ -8,12 +8,6 @@ module.exports = function getCampaignReply() {
       return next();
     }
 
-    if (process.env.DS_GAMBIT_DISABLED) {
-      req.reply.text = req.reply.brain;
-
-      return next();
-    }
-
     if (req.user.lastReplyType === 'signupPromptMessage') {
       if (req.reply.brain === 'decline_signup') {
         req.user.declineSignup();
@@ -27,6 +21,12 @@ module.exports = function getCampaignReply() {
         req.keyword = req.campaign.keywords[0];
       }
       // else "Sorry I didn't get that", repeat our prompt message.
+    }
+
+    if (process.env.DS_GAMBIT_DISABLED) {
+      req.reply.text = req.reply.brain;
+
+      return next();
     }
 
     return gambit.getGambitReply(req.userId, req.body.text, req.keyword)

--- a/lib/middleware/reply-campaign.js
+++ b/lib/middleware/reply-campaign.js
@@ -8,6 +8,18 @@ module.exports = function getCampaignReply() {
       return next();
     }
 
+    if (req.user.lastReplyType === 'signupPromptMessage') {
+      if (req.reply.brain === 'decline_signup') {
+        req.reply.type = 'signupDeclinedMessage';
+
+        return next();
+      } else if (req.reply.brain === 'post_signup') {
+        req.user.signupForCampaign(req.campaign);
+        req.keyword = req.campaign.keyword;
+      }
+      // else "Sorry I didn't get that", repeat our prompt message.
+    }
+
     return gambit.getGambitReply(req.userId, req.body.text, req.keyword)
       .then((gambitReplyText) => {
         req.reply.type = 'gambit';

--- a/lib/middleware/user-get.js
+++ b/lib/middleware/user-get.js
@@ -5,7 +5,7 @@ const helpers = require('../helpers');
 
 module.exports = function getUser() {
   return (req, res, next) => {
-    Users.findById(req.userId)
+    Users.findByPlatformId(req.platform, req.userId)
     .then((user) => {
       if (! user) return next();
 


### PR DESCRIPTION
If an inbound message receives a `gambit` reply from Slothie Brain, post the inbound message to the Gambit `/chatbot` endpoint to get the reply to send back.

* If a User has declined a Campaign Signup and texts in again, prompt with another random Campaign.

* Stores our `User._id` as a timestamp and queries by `platform`, `platformId` to avoid Gambit posting a legit phone number to Mobile Commons.