### PR TITLE
Deprecate noReply macro for user.paused check

### DIFF
--- a/brain/default.rive
+++ b/brain/default.rive
@@ -7,7 +7,7 @@
 
 + topic_support_crisis
 - Thanks for being brave and sharing that. If you want to talk to someone, our friends at CTL are\s
-^ here for you 24/7. Just send a text to 741741. They’ll listen!{topic=support_crisis}
+^ here for you 24/7. Just send a text to 741741. They’ll listen!{topic=supportCrisis}
 
 + [*] (i|someone|who) [@is] @hurting [me] [*]
 @ topic_support_crisis
@@ -19,7 +19,7 @@
 
 + topic_support_flagged
 - I'll try to find a human to help you. If you have a question, leave it here and we'll try to\s
-^ respond within 24 hours.{topic=support_flagged}
+^ respond within 24 hours.{topic=supportFlagged}
 
 + help me [*]
 @ topic_support_flagged
@@ -35,7 +35,7 @@
 
 + question
 - Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to cancel\s
-^ your request without waiting for a response, reply with "nevermind".{topic=support_question}
+^ your request without waiting for a response, reply with "nevermind".{topic=supportQuestion}
 
 + q
 @ question

--- a/brain/support.rive
+++ b/brain/support.rive
@@ -1,31 +1,34 @@
 // support.rive
-// The only reason we define separate topics is to segment the different triggers that cause
-// a user to end up in this topic.
 
-> topic support_crisis
+// We define support as a topic which DOESN'T inherit our random topic, so no default/random
+// triggers will be fired.
+> topic support
+
+// Because we don't inherient the random topic, we need to define a catchall.
+// @see https://github.com/aichaos/rivescript-js/issues/90#issuecomment-202500877.
++ *
+- gambit
+
+< topic
+
+// Defined as separate topics to group support requests, and to return different "exit"
+// messages.
+
+> topic support_crisis includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}
 
-+ *
-- noReply
-
 < topic
 
-> topic support_flagged
+> topic support_flagged includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}
 
-+ *
-- noReply
-
 < topic
 
-> topic support_question
-
-+ *
-- noReply
+> topic support_question includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}

--- a/brain/support.rive
+++ b/brain/support.rive
@@ -14,21 +14,21 @@
 // Defined as separate topics to group support requests, and to return different "exit"
 // messages.
 
-> topic support_crisis includes support
+> topic supportCrisis includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}
 
 < topic
 
-> topic support_flagged includes support
+> topic supportFlagged includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}
 
 < topic
 
-> topic support_question includes support
+> topic supportQuestion includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}

--- a/brain/support.rive
+++ b/brain/support.rive
@@ -1,17 +1,17 @@
 // support.rive
 
-// We define support as a topic which DOESN'T inherit our random topic, so no default/random
-// triggers will be fired.
+// We define support as a topic which DOESN'T inherit our random topic, so no triggers will catch.
 > topic support
 
-// Because we don't inherient the random topic, we need to define a catchall.
+// And because we don't inherit the random topic here, we need to define a catchall - otherwise
+// we'll receive an 'ERR: No Reply Matched' response from Rivescript.
 // @see https://github.com/aichaos/rivescript-js/issues/90#issuecomment-202500877.
 + *
 - gambit
 
 < topic
 
-// Defined as separate topics to group support requests, and to return different "exit"
+// Defined as separate topics to group support requests, and to potentially return different "exit"
 // messages.
 
 > topic supportCrisis includes support

--- a/config/lib/bot.js
+++ b/config/lib/bot.js
@@ -4,6 +4,6 @@ module.exports = {
   debug: process.env.RIVESCRIPT_DEBUG,
   directory: 'brain',
   concat: 'newline',
-  macroNames: ['post_signup', 'decline_signup', 'gambit', 'noReply'],
+  macroNames: ['post_signup', 'decline_signup', 'gambit'],
   menuCommand: 'menu',
 };

--- a/lib/middleware/template-noreply.js
+++ b/lib/middleware/template-noreply.js
@@ -6,7 +6,7 @@ module.exports = function replyNoReply() {
       return next();
     }
 
-    if (req.reply.brain === 'noReply') {
+    if (req.user.paused) {
       req.reply.template = 'noReply';
       req.reply.text = '';
     }


### PR DESCRIPTION
Instead of defining a `noReply` macro to use as our Support catchall, uses `gambit` as macro to run.
* In the `template-noreply` middleware, check whether `user.paused` instead of a `noReply` macro. This enables us to pause the User externally (like in [Dashbot](https://www.dashbot.io/sdk/pause)) to avoid sending more bot messages (instead of defining the non-reply via `noReply` macro)

DRY Support Topic by defining a single Support topic and its catchall, that other Support Topics can inherit.
* Added inline comments behind why Support doesn't inherit our Random topic. 
* Started wiki docs at https://github.com/DoSomething/slothie/wiki/Topics 
