### PR TITLE
Messages tweaks + CORS

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -101,6 +101,13 @@ campaignSchema.statics.findByKeyword = function (keyword) {
  * Virtual properties.
  * @TODO: Define these as fields on Gambit Campaigns upon signoff.
  */
+
+/* eslint-disable prefer-arrow-callback */
+// Disabling for these virtual properties because arrow functions are not a shortcut for function().
+// @see https://github.com/Automattic/mongoose/issues/4143
+ 
+// Even though this field exists on a Gambit Campaign, we're overriding it here because the copy
+// should prompt the User to text MENU back to find a new Campaign to do (doesn't exist on prod)
 campaignSchema.virtual('declinedSignupMessage').get(function () {
   return 'OK. Text MENU if you\'d like to find a different Campaign to join.';
 });
@@ -133,5 +140,6 @@ campaignSchema.virtual('invalidContinueResponseMessage').get(function () {
 
   return text;
 });
+/* eslint-enable prefer-arrow-callback */
 
 module.exports = mongoose.model('campaigns', campaignSchema);

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -105,7 +105,7 @@ campaignSchema.statics.findByKeyword = function (keyword) {
 /* eslint-disable prefer-arrow-callback */
 // Disabling for these virtual properties because arrow functions are not a shortcut for function().
 // @see https://github.com/Automattic/mongoose/issues/4143
- 
+
 // Even though this field exists on a Gambit Campaign, we're overriding it here because the copy
 // should prompt the User to text MENU back to find a new Campaign to do (doesn't exist on prod)
 campaignSchema.virtual('declinedSignupMessage').get(function () {

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -26,7 +26,7 @@ const messageSchema = new mongoose.Schema({
  */
 messageSchema.statics.createForRequest = function (req, direction) {
   const message = {
-    userId: req.userId,
+    userId: req.user._id,
     direction,
     topic: req.user.topic,
     platform: req.body.platform,

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -14,6 +14,7 @@ const messageSchema = new mongoose.Schema({
   direction: String,
   text: String,
   topic: String,
+  campaignId: Number,
   platform: String,
   template: String,
 });
@@ -35,8 +36,10 @@ messageSchema.statics.createForRequest = function (req, direction) {
   if (direction === 'outbound') {
     message.text = req.reply.text;
     message.template = req.reply.template;
+    message.campaignId = req.campaign._id;
   } else {
     message.text = req.body.text;
+    message.campaignId = req.user.campaignId;
   }
 
   return this.create(message);

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const configVars = {
+  corsEnabled: process.env.CORS_DISABLED || true,
   port: process.env.PORT || 5100,
   dbUri: process.env.MONGODB_URI || 'mongodb://localhost/slothie',
 };

--- a/lib/middleware/parse-ask-signup-response.js
+++ b/lib/middleware/parse-ask-signup-response.js
@@ -21,7 +21,7 @@ module.exports = function parseAskSignupResponse() {
     }
 
     if (req.reply.brain === 'confirmedCampaign') {
-      req.reply.template = 'gambit';      
+      req.reply.template = 'gambit';
 
       return next();
     }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,17 @@ const mongoose = require('mongoose');
 const restify = require('express-restify-mongoose');
 const config = require('./config');
 
+app.use((req, res, next) => {
+  if (! config.corsEnabled) {
+    return next();
+  }
+
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
+  return next();
+});
+
 mongoose.connect(config.dbUri);
 mongoose.Promise = global.Promise;
 


### PR DESCRIPTION
* Fixes bug -- store the `User._id` instead of `User.platformId` on a `Message.userId`
* Save user's current Campaign upon inbound message, and the `req.campaign` for outbound message.
* Enable CORS for now to get a Gambit Admin web app instance up on Heroku