### PR TITLE
Fix noReply when User is in Support

### DIFF
--- a/brain/default.rive
+++ b/brain/default.rive
@@ -7,7 +7,7 @@
 
 + topic_support_crisis
 - Thanks for being brave and sharing that. If you want to talk to someone, our friends at CTL are\s
-^ here for you 24/7. Just send a text to 741741. They’ll listen!{topic=supportCrisis}
+^ here for you 24/7. Just send a text to 741741. They’ll listen!{topic=support_crisis}
 
 + [*] (i|someone|who) [@is] @hurting [me] [*]
 @ topic_support_crisis
@@ -19,7 +19,7 @@
 
 + topic_support_flagged
 - I'll try to find a human to help you. If you have a question, leave it here and we'll try to\s
-^ respond within 24 hours.{topic=supportFlagged}
+^ respond within 24 hours.{topic=support_flagged}
 
 + help me [*]
 @ topic_support_flagged
@@ -35,7 +35,7 @@
 
 + question
 - Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to cancel\s
-^ your request without waiting for a response, reply with "nevermind".{topic=supportQuestion}
+^ your request without waiting for a response, reply with "nevermind".{topic=support_question}
 
 + q
 @ question

--- a/brain/support.rive
+++ b/brain/support.rive
@@ -14,21 +14,21 @@
 // Defined as separate topics to group support requests, and to potentially return different "exit"
 // messages.
 
-> topic supportCrisis includes support
+> topic support_crisis includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}
 
 < topic
 
-> topic supportFlagged includes support
+> topic support_flagged includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}
 
 < topic
 
-> topic supportQuestion includes support
+> topic support_question includes support
 
 + nevermind
 - Hi, you're chatting with <bot name> again. I'm a bot!{topic=random}

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -21,8 +21,8 @@ function loadingDone(batchNumber) {
   }
 }
 
-function loadingError(err) {
-  logger.error('bot.loadingError', err);
+function loadingError(error) {
+  logger.error('bot.loadingError', { error });
 }
 
 /**

--- a/lib/middleware/template-campaign.js
+++ b/lib/middleware/template-campaign.js
@@ -2,7 +2,9 @@
 
 module.exports = function renderReplyText() {
   return (req, res, next) => {
-    if (req.reply.text) {
+    // If we haven't rendered text yet, this is a campaign message except for edge-case when our
+    // template === noReply -- in that case our text is set to empty string.
+    if (req.reply.text || req.reply.template === 'noReply') {
       return next();
     }
 


### PR DESCRIPTION
* Fixes errors Rivescript throws from #19, doesn't like camelCase topic names.
* Fixes bug where User was getting a message back after entering Support.
 