### PR TITLE
Fix Campaign keyword

### DIFF
--- a/lib/middleware/campaign-keyword.js
+++ b/lib/middleware/campaign-keyword.js
@@ -8,6 +8,7 @@ module.exports = function getCampaignForKeyword() {
       return next();
     }
 
+    // Did User send a Campaign keyword?
     return Campaigns.findByKeyword(req.userCommand)
       .then((campaign) => {
         if (! campaign) {
@@ -16,6 +17,8 @@ module.exports = function getCampaignForKeyword() {
 
         req.campaign = campaign;
         req.keyword = req.userCommand;
+        // Gambit to handle the Confirmation/Continue reply.
+        req.reply.template = 'gambit';
 
         return next();
       });


### PR DESCRIPTION
Fixes bug where a Campaign keyword incoming message would get a `askContinueMessage` reply instead of the `gambit` reply.

## Before

<img width="1160" alt="screen shot 2017-07-11 at 6 48 45 am" src="https://user-images.githubusercontent.com/1236811/28071541-11fdddfa-6605-11e7-86be-0e288fdd9753.png">

## After
 
<img width="1151" alt="screen shot 2017-07-11 at 6 47 52 am" src="https://user-images.githubusercontent.com/1236811/28071555-1b79d51e-6605-11e7-90d4-49d42390ca3e.png">

cc @mikefantini
